### PR TITLE
Typo in the abstract method declariation. I'm not sure how this crept in...

### DIFF
--- a/src/Devture/Component/SmsSender/Gateway/GatewayInterface.php
+++ b/src/Devture/Component/SmsSender/Gateway/GatewayInterface.php
@@ -21,5 +21,5 @@ interface GatewayInterface {
     /**
      * @param string $url
      */
-    public function setBaseApiUri($url);
+    public function setBaseApiUrl($url);
 }


### PR DESCRIPTION
... but certainly not working now whilst trying to implement into a production application. It worked fine yesterday whilst in testing, so I guess I must have accidently typo'd AFTER my initial testing... Yeah I know... WTF right lol! Sorry any chance you can re-tag the 1.1 release as this is breaking ALL gateways as this is GatewayInterface abstract function declaration.
